### PR TITLE
Bug fixes related to status bar and editor modes

### DIFF
--- a/editor.cpp
+++ b/editor.cpp
@@ -50,6 +50,11 @@ EditorMode EditorState::getMode() const {
     return currentMode;
 }
 
+int EditorState::getTextWindowHeight(){
+    // The text window is the total height minus the status bar
+    return terminalRows - 1;
+}
+
 void EditorState::setRows(int rows) { terminalRows = rows; }
 void EditorState::setCols(int cols) { terminalCols = cols; }
 void EditorState::setRowOffset(int val) { rowOffset = val; }

--- a/editor.hpp
+++ b/editor.hpp
@@ -51,6 +51,7 @@ public:
     int getCursorY();
     int getCursorFileY();
     int getCursorFileX();
+    int getTextWindowHeight();   // This is after considering that the last row is reserved for status bar
     std::vector<textRow> getTextRows();
     textRow& getTextRow(int idx);
     std::string getFileName();

--- a/main.cpp
+++ b/main.cpp
@@ -319,8 +319,10 @@ void editorProcessKeypress() {  // Main function which handles the different key
 		E.setRowOffset(currCursorFileY);
 	}
 	
-	if(currCursorFileY>=E.getRowOffset()+terminalRows){
-		E.setRowOffset(currCursorFileY-terminalRows+1);
+	int textWindowHeight = E.getTextWindowHeight();
+
+	if(currCursorFileY>=E.getRowOffset()+textWindowHeight){
+		E.setRowOffset(currCursorFileY-textWindowHeight+1);
 	}
 
 	if(currCursorFileX < E.getColOffset()){
@@ -339,6 +341,10 @@ void editorProcessKeypress() {  // Main function which handles the different key
 	int r = E.getCursorFileY() - rowOffset;
 	int c = E.getCursorFileX() - colOffset;
 
+	if (r >= E.getTextWindowHeight()) {
+    	r = E.getTextWindowHeight() - 1;
+	}
+
 	E.setCursorY(r);
 	E.setCursorX(c);
 }
@@ -353,6 +359,9 @@ int main(int argc, char* argv[])
 	clear(); 
 
 	initEditor();
+
+	printf("\x1b[2 q"); // Set initial cursor shape to block for Normal mode
+    fflush(stdout);
 
 	if(argc>=2){
 		handleFile(argv);


### PR DESCRIPTION
## 1. Fix: Set Initial Cursor Shape to Block in Normal Mode

* **Problem:** When the editor first launched, it started correctly in `Normal Mode`, but the cursor appeared as a thin line (the `Insert Mode` cursor) instead of a block. This was because the cursor-changing logic in `refreshScreen()` only triggered when the mode *changed* from its previous state. On startup, the initial and last modes were both `Normal`, so the logic was skipped.

* **Solution:** Explicitly set the cursor shape to a block at the very beginning of the program. A single `printf("\x1b[2 q");` was added in the `main()` function right after initializing ncurses. This ensures the correct block cursor is displayed from the moment the editor opens.

---

## 2. Fix: Prevent Cursor from Moving onto Status Bar

* **Problem:** When navigating with the down arrow key, the cursor could physically move onto the last line of the terminal, overlapping with the newly implemented status bar. The scrolling and cursor calculation logic didn't account for this reserved line.

* **Solution:** The code was updated to make the editor's layout logic more robust.
    1.  A new method, `getTextWindowHeight()`, was added to the `EditorState` class. This method defines the text area as the total terminal height minus the one line reserved for the status bar.
    2.  The central scrolling logic in `editorProcessKeypress()` was updated to use this new, smaller height for its calculations. This ensures the editor scrolls correctly before the cursor hits the status bar line.